### PR TITLE
✅  GitHub Pages Deployment Fix

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -54,12 +54,6 @@ jobs:
         env:
           JEKYLL_ENV: "production"
 
-      # - name: Test site
-      #   run: |
-      #     bundle exec htmlproofer _site \
-      #       \-\-disable-external=true \
-      #       \-\-ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/"
-
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v3.0.1
         with:

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -61,7 +61,6 @@ jobs:
           name: github-pages
 
   deploy:
-    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
# Problem
- artifact, deploy version
- deploy is failed

# Solved
- change artifact and deploy version to latest version
- In artifact part, add `name: github-pages`. Because the artifact must be named `github-pages` so that actions/deploy-pages can locate it.

  